### PR TITLE
fixes to build on fresh Oracle Enterprise Linux 7 and 6.4

### DIFF
--- a/el/README.md
+++ b/el/README.md
@@ -31,5 +31,5 @@ On a brand new "Enterprise Linux" installation (tested with official Dockerimage
     cd packaging/el/
     spectool -g -C ~/rpmbuild/SOURCES mapserver-7.0.spec
     yum-builddep -y mapserver-7.0.spec
-    QA_RPATHS=0x0001 pmbuild -ba --target x86_64 mapserver-7.0.spec
+    QA_RPATHS=$[ 0x0001|0x0002 ] rpmbuild -ba --target x86_64 mapserver-7.0.spec
 

--- a/el/README.md
+++ b/el/README.md
@@ -12,3 +12,24 @@ On a brand new "Enterprise Linux" installation (only tested on CentOS & Red Hat 
     yum-builddep -y mapserver-6.4.spec
     rpmbuild -ba --target x86_64 mapserver-6.4.spec
 
+Instructions to build RPMs for Mapserver 7.0
+============================================
+
+On a brand new "Enterprise Linux" installation (tested with official Dockerimage oraclelinux:latest) including EPEL repository and activated ol7_optional_latest:
+
+    # activate ol7_optional_latest and EPEL
+    yum-config-manager --enable ol7_optional_latest
+    yum update -y
+    yum install -y tar wget
+    wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+    rpm -ivh epel-release-7-10.noarch.rpm
+
+    # do the RPM build
+    yum -y install git rpm-build rpmdevtools yum-utils
+    rpmdev-setuptree
+    git clone https://github.com/mapserver/packaging.git
+    cd packaging/el/
+    spectool -g -C ~/rpmbuild/SOURCES mapserver-7.0.spec
+    yum-builddep -y mapserver-7.0.spec
+    QA_RPATHS=0x0001 pmbuild -ba --target x86_64 mapserver-7.0.spec
+

--- a/el/mapserver-6.4.spec
+++ b/el/mapserver-6.4.spec
@@ -16,7 +16,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       httpd
 Requires:       dejavu-sans-fonts
 
-BuildRequires:  cmake 
+BuildRequires:  cmake make gcc gcc-c++
 BuildRequires:  libXpm-devel readline-devel librsvg2-devel
 BuildRequires:  httpd-devel php-devel libxslt-devel pam-devel fcgi-devel
 BuildRequires:  perl(ExtUtils::MakeMaker)

--- a/el/mapserver-7.0.spec
+++ b/el/mapserver-7.0.spec
@@ -16,7 +16,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       httpd
 Requires:       dejavu-sans-fonts
 
-BuildRequires:  cmake 
+BuildRequires:  cmake  gcc gcc-c++
 BuildRequires:  libXpm-devel readline-devel librsvg2-devel
 BuildRequires:  httpd-devel php-devel libxslt-devel pam-devel fcgi-devel
 BuildRequires:  perl(ExtUtils::MakeMaker)

--- a/el/mapserver-7.0.spec
+++ b/el/mapserver-7.0.spec
@@ -16,7 +16,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       httpd
 Requires:       dejavu-sans-fonts
 
-BuildRequires:  cmake  gcc gcc-c++
+BuildRequires:  cmake make gcc gcc-c++
 BuildRequires:  libXpm-devel readline-devel librsvg2-devel
 BuildRequires:  httpd-devel php-devel libxslt-devel pam-devel fcgi-devel
 BuildRequires:  perl(ExtUtils::MakeMaker)


### PR DESCRIPTION
Hi, trying to build RPMs für Oracle Linux failed for 6.4 and 7.0 when using the spec-files. there where BuildRequires gcc, gcc-c++ and make missing.
With those changes the RPM build almost works. Almost, because i had to add a
QA_RPATHS=$[ 0x0001|0x0002 ] before rpmbuild.
May be anyone more in code and packaging knows if this can be fixed or is not relevant.
